### PR TITLE
Update formula to include distnoted patch

### DIFF
--- a/files/brews/emacs.rb
+++ b/files/brews/emacs.rb
@@ -5,7 +5,7 @@ class Emacs < Formula
   url 'http://ftpmirror.gnu.org/emacs/emacs-24.3.tar.gz'
   mirror 'http://ftp.gnu.org/pub/gnu/emacs/emacs-24.3.tar.gz'
   sha256 '0098ca3204813d69cd8412045ba33e8701fa2062f4bff56bedafc064979eef41'
-  version '24.3-boxen3'
+  version '24.3-boxen4'
 
   skip_clean 'share/info' # Keep the docs
 
@@ -16,42 +16,55 @@ class Emacs < Formula
   option "keep-ctags", "Don't remove the ctags executable that emacs provides"
   option "japanese", "Patch for Japanese input methods"
 
-  if build.include? "use-git-head"
-    head 'http://git.sv.gnu.org/r/emacs.git'
-  else
-    head 'bzr://http://bzr.savannah.gnu.org/r/emacs/trunk'
-  end
+  head do
+    if build.include? "use-git-head"
+      url 'http://git.sv.gnu.org/r/emacs.git'
+    else
+      url 'bzr://http://bzr.savannah.gnu.org/r/emacs/trunk'
+    end
 
-  if build.head? or build.include? "cocoa"
     depends_on :autoconf
     depends_on :automake
   end
 
+  stable do
+    if build.include? "cocoa"
+      depends_on :autoconf
+      depends_on :automake
+    end
+
+    # Fix default-directory on Cocoa and Mavericks.
+    # Fixed upstream in r114730 and r114882.
+    patch :p0, :DATA
+
+    # Make native fullscreen mode optional, mostly from upstream r111679
+    patch do
+      url "https://gist.github.com/scotchi/7209145/raw/a571acda1c85e13ed8fe8ab7429dcb6cab52344f/ns-use-native-fullscreen-and-toggle-frame-fullscreen.patch"
+      sha1 "cb4cc4940efa1a43a5d36ec7b989b90834b7442b"
+    end
+
+    # Fix memory leaks in NS version from upstream r114945
+    patch do
+      url "https://gist.github.com/anonymous/8553178/raw/c0ddb67b6e92da35a815d3465c633e036df1a105/emacs.memory.leak.aka.distnoted.patch.diff"
+      sha1 "173ce253e0d8920e0aa7b1464d5635f6902c98e7"
+    end
+
+    # "--japanese" option:
+    # to apply a patch from MacEmacsJP for Japanese input methods
+    patch :p0 do
+      url "http://sourceforge.jp/projects/macemacsjp/svn/view/inline_patch/trunk/emacs-inline.patch?view=co&revision=583&root=macemacsjp&pathrev=583"
+      sha1 "61a6f41f3ddc9ecc3d7f57379b3dc195d7b9b5e2"
+    end if build.include? "cocoa" and build.include? "japanese"
+  end
+
   depends_on 'pkg-config' => :build
-  depends_on :x11 if build.include? "with-x"
+  depends_on :x11 if build.with? "x"
   depends_on 'gnutls' => :optional
 
   fails_with :llvm do
     build 2334
     cause "Duplicate symbol errors while linking."
   end
-
-  def patches
-    p = {
-      # Fix default-directory on Cocoa and Mavericks.
-      # Fixed upstream in r114730 and r114882.
-      :p0 => [ DATA ],
-      # Make native fullscreen mode optional, mostly from
-      # upstream r111679
-      :p1 => [ 'https://gist.github.com/scotchi/7209145/raw/a571acda1c85e13ed8fe8ab7429dcb6cab52344f/ns-use-native-fullscreen-and-toggle-frame-fullscreen.patch' ]
-    }
-    # "--japanese" option:
-    # to apply a patch from MacEmacsJP for Japanese input methods
-    if build.include? "cocoa" and build.include? "japanese"
-      p[:p0].push("http://sourceforge.jp/projects/macemacsjp/svn/view/inline_patch/trunk/emacs-inline.patch?view=co&revision=583&root=macemacsjp&pathrev=583")
-    end
-    p
-  end unless build.head?
 
   # Follow MacPorts and don't install ctags from Emacs. This allows Vim
   # and Emacs and ctags to play together without violence.
@@ -103,7 +116,7 @@ class Emacs < Formula
         #{prefix}/Emacs.app/Contents/MacOS/Emacs -nw  "$@"
       EOS
     else
-      if build.include? "with-x"
+      if build.with? "x"
         # These libs are not specified in xft's .pc. See:
         # https://trac.macports.org/browser/trunk/dports/editors/emacs/Portfile#L74
         # https://github.com/Homebrew/homebrew/issues/8156
@@ -135,6 +148,12 @@ class Emacs < Formula
       end
     end
     return s
+  end
+
+  test do
+    output = `'#{bin}/emacs' --batch --eval="(print (+ 2 2))"`
+    assert $?.success?
+    assert_equal "4", output.strip
   end
 end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,11 +5,13 @@
 #   include emacs
 
 class emacs(
-  $install_options = [ '--cocoa' ],
-  ) {
+  $install_options = [
+    '--cocoa',
+  ],
+) {
   require homebrew
 
-  $version = '24.3-boxen3'
+  $version = '24.3-boxen4'
 
   homebrew::formula { 'emacs':
     before => Package['boxen/brews/emacs'] ;


### PR DESCRIPTION
Emacs 24.3 is known to cause issues on OSX Mavericks, especially when waking from sleep, which manifest as the distnoted process hogging CPU cycles. There's a patch in trunk (24.4), which has been back ported in the upstream homebrew formula.

I've merged in all the upstream homebrew formula changes, which mainly reflect changes in core homebrew itself. The only significant change is the addition of this patch (referred as a 'memory leak' patch).
